### PR TITLE
chore: release v0.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "bytes"


### PR DESCRIPTION



## 🤖 New release

* `cabin-cli`: 0.0.0
* `cabin-db`: 0.0.0
* `cabin-storage`: 0.0.0
* `cabin-vdbe`: 0.0.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `cabin-cli`

<blockquote>

## [0.0.0](https://github.com/jobala/cabin/releases/tag/cabin-cli-v0.0.0) - 2025-09-16

### Other

- add changelog files
</blockquote>

## `cabin-db`

<blockquote>

## [0.0.0](https://github.com/jobala/cabin/releases/tag/cabin-db-v0.0.0) - 2025-09-16

### Other

- add changelog files
</blockquote>

## `cabin-storage`

<blockquote>

## [0.0.0](https://github.com/jobala/cabin/releases/tag/cabin-storage-v0.0.0) - 2025-09-16

### Other

- add changelog files
</blockquote>

## `cabin-vdbe`

<blockquote>

## [0.0.0](https://github.com/jobala/cabin/releases/tag/cabin-vdbe-v0.0.0) - 2025-09-16

### Other

- add changelog files
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).